### PR TITLE
Chore: Dockerfileのgoのversionを1.24に修正

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
## 概要

dockerfile内のgoのバージョンが不適切だったためビルドが落ちている
dockerfileのgoのバージョンを1.24に上げた

## 関連Issue

<!-- 関連するIssueがあればリンクしてください -->
なし

## 変更内容

<!-- 具体的な変更内容を箇条書きで記載してください -->

- Dockerfileのgoのバージョンを1.24に修正

## スクリーンショット

<!-- UIに関する変更がある場合は、変更前後のスクリーンショットを添付してください -->

Before: goのバージョンが1.20でビルドした状態
After: goのバージョンが1.24でビルドした状態

| Before | After |
|--------|-------|
|  <img width="930" height="490" alt="Screenshot 2026-01-15 at 10 06 48 PM" src="https://github.com/user-attachments/assets/335112fe-0627-417c-a6cc-ecca80508869" /> | <img width="928" height="390" alt="Screenshot 2026-01-15 at 10 09 12 PM" src="https://github.com/user-attachments/assets/297635c0-f235-4ffe-a91a-784130d3e370" /> |

## テスト

<!-- 動作確認した内容を記載してください -->

- [x] ローカル環境で動作確認済み
- [x] 関連する機能への影響がないことを確認済み

## レビュアーへのコメント

<!-- レビュー時に特に確認してほしい点があれば記載してください -->

